### PR TITLE
ignores .DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.vscode
+**/.DS_Store


### PR DESCRIPTION
.DS_Store is a hidden file created by macOS, so let's ignore this too.